### PR TITLE
BVWS-219: Change RESTConnector name to RESTBridge

### DIFF
--- a/Livre.cmake
+++ b/Livre.cmake
@@ -4,7 +4,7 @@ endif()
 set(LIVRE_PACKAGE_VERSION 0.2.0)
 set(LIVRE_REPO_URL https://github.com/BlueBrain/Livre)
 set(LIVRE_DEPENDS BBPTestData OpenMP Tuvok VTune GLEW_MX zeq FlatBuffers
-  RESTConnector LibJpegTurbo
+  RESTBridge LibJpegTurbo
   REQUIRED Boost Collage dash Equalizer Lunchbox OpenGL PNG Qt5Core Qt5OpenGL
            Qt5Widgets Threads)
 set(LIVRE_BOOST_COMPONENTS

--- a/RESTBridge.cmake
+++ b/RESTBridge.cmake
@@ -1,0 +1,6 @@
+set(RESTBRIDGE_VERSION 0.1)
+set(RESTBRIDGE_REPO_URL https://github.com/BlueBrain/RESTBridge.git)
+set(RESTBRIDGE_DEPENDS REQUIRED Boost cppnetlib Lunchbox zeq FlatBuffers
+                          OPTIONAL bluebrain)
+set(RESTBRIDGE_BOOST_COMPONENTS "unit_test_framework program_options system thread")
+set(RESTBRIDGE_DEB_DEPENDS libboost-test-dev libboost-program-options-dev libboost-system-dev libboost-thread-dev)

--- a/RESTConnector.cmake
+++ b/RESTConnector.cmake
@@ -1,6 +1,0 @@
-set(RESTCONNECTOR_VERSION 0.1)
-set(RESTCONNECTOR_REPO_URL https://github.com/BlueBrain/RESTConnector.git)
-set(RESTCONNECTOR_DEPENDS REQUIRED Boost cppnetlib Lunchbox zeq FlatBuffers
-                          OPTIONAL bluebrain)
-set(RESTCONNECTOR_BOOST_COMPONENTS "unit_test_framework program_options system thread")
-set(RESTCONNECTOR_DEB_DEPENDS libboost-test-dev libboost-program-options-dev libboost-system-dev libboost-thread-dev)


### PR DESCRIPTION
I apparently cannot remove the RESTConnector.cmake file. Can the project admin do it for me?